### PR TITLE
修正node 0.8以上路径分隔符问题

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -163,7 +163,7 @@ Compiler.prototype._moduleName = function(filePath, pkg){
     if(!utils.startWith(relativePkgPath, pkg.name + '/') && pkg.name !== 'kissy'){
         moduleName = pkg.name + '/' + moduleName;
     }
-    return path.normalize(moduleName.replace(/\.js$/i, ''));
+    return path.normalize(moduleName.replace(/\.js$/i, '')).replace( /\\/g, '/' );
 };
 Compiler.prototype._buildCombo = function(mod){
     var self = this,


### PR DESCRIPTION
修正node v0.8以上版本路径'/'变为'\'的问题
