### PR TITLE
:wrench: fix dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "iconv-lite": ">=0.1.0",
     "colors": ">=0.6.0-1",
-    "lodash": "",
-    "uglify-js": ""
+    "lodash": "^4.17.4",
+    "uglify-js": "^2.8.23"
   },
   "devDependencies": {
     "mocha": "~1.4.1",


### PR DESCRIPTION
但是本项目依赖没有指定`uglify-js`等版本，近日`uglify-js`升级了大版本导致模块解析出错

```bash
Running "kmc:main" (kmc) task
/**/*.js
Warning: TypeError: file parse error. The file is /**/*.js Use --force to continue.
```