### PR TITLE
兼容 `path.extname` 在 node 6.x 版本下强制要求 String

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ module.exports = {
 		var outputFile = outputDir ? path.resolve(outputDir,path.basename(inputFile)) : '';
         var c = new Compiler(config,outputFile);
         var result = c.analyze(inputFile);
-        content = c.combo(fixModuleName, outputDir,comboOnly,path.extname(depFileName)==='.json');
+        content = c.combo(fixModuleName, outputDir,comboOnly,path.extname(depFileName || '')==='.json');
         if(content && depFileName){
             utils.writeFileSync(depFileName, content, depFileCharset);
         }


### PR DESCRIPTION
`path.extname` 在 node 4.x 下传入 `undefined` 不会报错返回 `''`，但在 6.x 下会报错：

```
> path.extname()
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.extname (path.js:1431:5)
    at repl:1:6
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:73:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:346:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:545:10)
```

因为 grunt-kmc 这一行可能会传入 `undefined` 给 `depFileName`: https://github.com/daxingplay/grunt-kmc/blob/master/tasks/kmc.js#L127